### PR TITLE
French translations

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,0 +1,5 @@
+fr:
+  errors:
+    messages:
+      countries_alpha2_invalid: "%{alpha2} n'est pas valide"
+      countries_alpha3_invalid: "%{alpha3} n'est pas valide"


### PR DESCRIPTION
@Ohmmanz :handshake: 

The name of the locales (such as `en`, `pt-BR`, `fr` and so on) follows the Rails i18n locales list. The complete list of "locale names" is in this URL (check the name of .yml files) -> https://github.com/svenfuchs/rails-i18n/tree/master/rails/locale

In this gem (gem is the formal name for a ruby library), we need to provide translations for all available locales in Rails. This PR has the structure for a translation in a specific locale (`fr`), that is composed by:

For a locale `XX`, create the file `config/locales/XX.yml` with the following content:
```yaml
XX:
  errors:
    messages:
      countries_alpha2_invalid: '%{alpha2} the message in the locale indicating that alpha2 is invalid'
      countries_alpha3_invalid: '%{alpha3} the message in the locale indicating that alpha3 is invalid'
```

Note that `%{alpha2}` and `%{alpha3}` are special tokens that has its values inserted dynamically by gem, that generates the complete output, such as (for example):

- US is not valid (alpha2 - en)
- BRL não é válido (alpha3 - pt-BR)

The identation of each level is 2 spaces, following the convention of Ruby/Rails practices ( https://github.com/rubocop-hq/ruby-style-guide#spaces-indentation ).
The alpha2 and alpha3 are ISO codes used to identity countries in a standardized way ( https://www.iso.org/iso-3166-country-codes.html ). 

Thanks! :+1: 